### PR TITLE
Preserve transcription results

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,7 +5,7 @@ import { ApiKeyDialog } from "./components/api-key-dialog";
 import { Transcript } from "./components/transcript";
 import { Button } from "./components/ui/button";
 import { TalkingPoint } from "./types";
-import { useSpeechRecognition } from "./use-speech-recognition";
+import { useTranscription } from "./use-transcription";
 
 function App() {
   const [isTranscribing, setIsTranscribing] = useState(false);
@@ -23,7 +23,7 @@ function App() {
     }
   }, [isTranscribing]);
 
-  const transcriptionResults = useSpeechRecognition({
+  const transcriptionResults = useTranscription({
     enabled: isTranscribing,
   });
 
@@ -37,8 +37,8 @@ function App() {
     [openAiKey],
   );
 
-  const transcript = Array.from(transcriptionResults || [])
-    .map((result) => result[0].transcript)
+  const transcript = transcriptionResults
+    .map((result) => result.transcript)
     .join("");
 
   return (
@@ -60,7 +60,7 @@ function App() {
         </div>
         <div className="w-1/2 pl-8">
           {snaps.length > 0 ? (
-            <ul className="overflow-y-auto list-disc list-inside">
+            <ul className="list-inside list-disc overflow-y-auto">
               {snaps.map((snap) => (
                 <li
                   key={snap.summary}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,20 +1,14 @@
-import { useEffect, useMemo, useState } from "react";
-import { useLocalStorage, usePrevious } from "react-use";
+import { useMemo, useState } from "react";
+import { useLocalStorage } from "react-use";
 import { AI } from "./ai";
 import { ApiKeyDialog } from "./components/api-key-dialog";
 import { Transcript } from "./components/transcript";
 import { Button } from "./components/ui/button";
 import { TalkingPoint } from "./types";
-import {
-  useTranscription,
-  type TranscriptionResult,
-} from "./use-transcription";
-
-// TODO: use a statemachine because the different `prev` states are confusing
+import { useTranscription } from "./use-transcription";
 
 function App() {
   const [isTranscribing, setIsTranscribing] = useState(false);
-  const prevIsTranscribing = usePrevious(isTranscribing);
 
   // Snaps are talking points that the listener wants to remember
   const [snaps, setSnaps] = useState<TalkingPoint[]>([]);
@@ -22,35 +16,9 @@ function App() {
     null,
   );
 
-  const currentTranscriptionResults = useTranscription({
+  const transcriptionResults = useTranscription({
     enabled: isTranscribing,
   });
-  const [oldTranscriptionResults, setOldTranscriptionResults] = useState<
-    TranscriptionResult[]
-  >([]);
-  const transcriptionResults = [
-    ...oldTranscriptionResults,
-    ...currentTranscriptionResults,
-  ];
-
-  // TODO: probably move this to useTranscription
-  // When a new transcription is started, save the current transcription results in state.
-  // This is useful because transcription results are cleared when starting transcription.
-  useEffect(() => {
-    if (
-      !prevIsTranscribing &&
-      isTranscribing &&
-      currentTranscriptionResults.length > 0
-    ) {
-      setOldTranscriptionResults((prev) => {
-        return [
-          ...prev,
-          ...currentTranscriptionResults,
-          { transcript: " ", isFinal: true }, // add a break between transcription sessions
-        ];
-      });
-    }
-  }, [prevIsTranscribing, isTranscribing, currentTranscriptionResults]);
 
   const [openAiKey, setOpenAiKey] = useLocalStorage<string>(
     "openai-api-key",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -33,6 +33,7 @@ function App() {
     ...currentTranscriptionResults,
   ];
 
+  // TODO: probably move this to useTranscription
   // When a new transcription is started, save the current transcription results in state.
   // This is useful because transcription results are cleared when starting transcription.
   useEffect(() => {
@@ -41,10 +42,13 @@ function App() {
       isTranscribing &&
       currentTranscriptionResults.length > 0
     ) {
-      setOldTranscriptionResults((prev) => [
-        ...prev,
-        ...currentTranscriptionResults,
-      ]);
+      setOldTranscriptionResults((prev) => {
+        return [
+          ...prev,
+          ...currentTranscriptionResults,
+          { transcript: " ", isFinal: true }, // add a break between transcription sessions
+        ];
+      });
     }
   }, [prevIsTranscribing, isTranscribing, currentTranscriptionResults]);
 

--- a/src/components/transcript.tsx
+++ b/src/components/transcript.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils";
 import { splitTranscript } from "@/string-utils";
 import { TalkingPoint } from "@/types";
+import type { TranscriptionResult } from "@/use-transcription";
 import { useEffect, useRef } from "react";
 
 export function Transcript({
@@ -9,13 +10,13 @@ export function Transcript({
   highlightedSnaps,
   className,
 }: {
-  transcriptionResults: SpeechRecognitionResultList | null;
+  transcriptionResults: TranscriptionResult[];
   snaps: TalkingPoint[];
   highlightedSnaps: TalkingPoint[];
   className?: string;
 }) {
-  const transcript = Array.from(transcriptionResults || [])
-    .map((result) => result[0].transcript)
+  const transcript = transcriptionResults
+    .map((result) => result.transcript)
     .join("");
   const segments = splitTranscript(transcript, snaps);
 

--- a/src/use-transcription.ts
+++ b/src/use-transcription.ts
@@ -1,0 +1,31 @@
+import { useWebSpeechRecognition } from "./use-web-speech-recognition";
+
+/** A piece of a transcript. */
+export interface TranscriptionResult {
+  /** Textual representation of what was said. */
+  transcript: string;
+  /** Whether the result may change in the future or not. */
+  isFinal: boolean;
+}
+
+/** Maps the result of the Web Speech API Speech Recognition to our common interface. */
+function mapResults(
+  webResults: SpeechRecognitionResultList,
+): TranscriptionResult[] {
+  return Array.from(webResults).map((result) => ({
+    transcript: result.item(0).transcript,
+    isFinal: result.isFinal,
+  }));
+}
+
+/**
+ * High-level interface for transcribing voice from the device microphone.
+ */
+export function useTranscription({
+  enabled,
+}: {
+  enabled: boolean;
+}): TranscriptionResult[] {
+  const webResults = useWebSpeechRecognition({ enabled });
+  return webResults ? mapResults(webResults) : [];
+}

--- a/src/use-web-speech-recognition.ts
+++ b/src/use-web-speech-recognition.ts
@@ -1,10 +1,16 @@
 import dedent from "dedent";
 import { useEffect, useMemo, useState } from "react";
+import type { useTranscription } from "./use-transcription";
 
 const SpeechRecognition =
   window.SpeechRecognition || window.webkitSpeechRecognition;
 
-export function useSpeechRecognition({
+/**
+ * Transcribes voice from the device microphone using the Web Speech API.
+ * This is a lower-level interface. A higher-level interface is available in {@link useTranscription}.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API
+ */
+export function useWebSpeechRecognition({
   enabled,
 }: {
   enabled: boolean;
@@ -17,27 +23,25 @@ export function useSpeechRecognition({
     return recognition;
   }, []);
 
-  const [transcriptionResults, setTranscriptionResults] =
-    useState<SpeechRecognitionResultList | null>(null);
+  const [results, setResults] = useState<SpeechRecognitionResultList | null>(
+    null,
+  );
 
   // While transcribing, listen for speech and update the transcription state
   useEffect(() => {
-    const handleTranscriptionResult = (event: SpeechRecognitionEvent) => {
-      setTranscriptionResults(event.results);
+    const handleResult = (event: SpeechRecognitionEvent) => {
+      setResults(event.results);
     };
 
     const startTranscription = () => {
-      setTranscriptionResults(null);
-      speechRecognition.addEventListener("result", handleTranscriptionResult);
+      setResults(null);
+      speechRecognition.addEventListener("result", handleResult);
       speechRecognition.start();
     };
 
     const stopTranscription = () => {
       if (speechRecognition) {
-        speechRecognition.removeEventListener(
-          "result",
-          handleTranscriptionResult,
-        );
+        speechRecognition.removeEventListener("result", handleResult);
         speechRecognition.stop();
       }
     };
@@ -53,11 +57,11 @@ export function useSpeechRecognition({
     };
   }, [speechRecognition, enabled]);
 
-  return transcriptionResults;
+  return results;
 }
 
 // @ts-ignore
-const MOCK_TRANSCRIPTION_RESULTS = [
+const MOCK_RESULTS = [
   {
     isFinal: true,
     0: {


### PR DESCRIPTION
### Description

Previously, when starting transcription, any existing transcript would be cleared without warning. This was not obvious and could lead to loss of work. This PR preserves the transcript indefinitely, until the page is closed or refreshed.

### Implementation

I added a high-level abstraction over the speech recognition API, called `useTranscription`. The original `useSpeechRecognition` has been renamed to `useWebSpeechRecognition`. My motivation is that the `useWebSpeechRecognition` hook should have a single concern: reactify the `SpeechRecognition` API. Additional features such as preserving state on stop/start and mapping to another data model are handled by the high-level `useTranscription` instead.