### PR TITLE
Refactor transcription hooks using a state machine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-slot": "^1.1.0",
+        "@xstate/react": "^4.1.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "damerau-levenshtein": "^1.0.8",
@@ -25,6 +26,7 @@
         "react-use": "^17.5.0",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
+        "xstate": "^5.16.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -2013,6 +2015,24 @@
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
       "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
+    },
+    "node_modules/@xstate/react": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-4.1.1.tgz",
+      "integrity": "sha512-pFp/Y+bnczfaZ0V8B4LOhx3d6Gd71YKAPbzerGqydC2nsYN/mp7RZu3q/w6/kvI2hwR/jeDeetM7xc3JFZH2NA==",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.2",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "xstate": "^5.11.0"
+      },
+      "peerDependenciesMeta": {
+        "xstate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -6932,6 +6952,19 @@
         }
       }
     },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-sidecar": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
@@ -6951,6 +6984,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -7362,6 +7403,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/xstate": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.16.0.tgz",
+      "integrity": "sha512-qws7r2nsCsQ/Qgpn75+FYM84M88/nopGsxij/qYNSOyKJKO4n7x8B5isQKv6DMruyF4gGg7y4gsFDTzJUlKcWw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/xstate"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
+    "@xstate/react": "^4.1.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "damerau-levenshtein": "^1.0.8",
@@ -30,6 +31,7 @@
     "react-use": "^17.5.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
+    "xstate": "^5.16.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,12 +14,7 @@ function App() {
     null,
   );
 
-  const {
-    results,
-    start,
-    stop,
-    state: transcriptionState,
-  } = useTranscription();
+  const transcription = useTranscription();
 
   const [openAiKey, setOpenAiKey] = useLocalStorage<string>(
     "openai-api-key",
@@ -31,15 +26,17 @@ function App() {
     [openAiKey],
   );
 
-  const transcript = results.map((result) => result.transcript).join("");
+  const transcript = transcription.results
+    .map((result) => result.transcript)
+    .join("");
 
   return (
     <div className="flex h-screen w-full flex-col items-center bg-background p-16 pb-0">
       <div className="mb-8 flex min-h-0 w-full grow text-gray-900">
         <div className="w-1/2 border-r border-gray-300 pr-8">
-          {transcript || transcriptionState === "transcribing" ? (
+          {transcript || transcription.state === "transcribing" ? (
             <Transcript
-              transcriptionResults={results}
+              transcriptionResults={transcription.results}
               snaps={snaps}
               highlightedSnaps={highlightedSnap ? [highlightedSnap] : []}
               className="h-full w-full"
@@ -81,17 +78,17 @@ function App() {
         <div className="flex gap-4">
           <Button
             onClick={() => {
-              if (transcriptionState === "transcribing") {
-                stop();
+              if (transcription.state === "transcribing") {
+                transcription.stop();
               } else {
-                start();
+                transcription.start();
               }
             }}
             variant={
-              transcriptionState === "transcribing" ? "outline" : "default"
+              transcription.state === "transcribing" ? "outline" : "default"
             }
           >
-            {transcriptionState === "transcribing"
+            {transcription.state === "transcribing"
               ? "Stop Transcription"
               : "Start Transcription"}
           </Button>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,7 +14,12 @@ function App() {
     null,
   );
 
-  const { results, start, stop, state: transcriptionState } = useTranscription();
+  const {
+    results,
+    start,
+    stop,
+    state: transcriptionState,
+  } = useTranscription();
 
   const [openAiKey, setOpenAiKey] = useLocalStorage<string>(
     "openai-api-key",
@@ -26,9 +31,7 @@ function App() {
     [openAiKey],
   );
 
-  const transcript = results
-    .map((result) => result.transcript)
-    .join("");
+  const transcript = results.map((result) => result.transcript).join("");
 
   return (
     <div className="flex h-screen w-full flex-col items-center bg-background p-16 pb-0">
@@ -84,9 +87,13 @@ function App() {
                 start();
               }
             }}
-            variant={transcriptionState === "transcribing" ? "outline" : "default"}
+            variant={
+              transcriptionState === "transcribing" ? "outline" : "default"
+            }
           >
-            {transcriptionState === "transcribing" ? "Stop Transcription" : "Start Transcription"}
+            {transcriptionState === "transcribing"
+              ? "Stop Transcription"
+              : "Start Transcription"}
           </Button>
           <Button
             disabled={!ai || !transcript}

--- a/src/use-transcription.ts
+++ b/src/use-transcription.ts
@@ -97,13 +97,8 @@ export function useTranscription(): {
     }),
   );
 
-  const results = [
-    ...state.context.oldResults,
-    ...state.context.currentResults,
-  ];
-
   return {
-    results,
+    results: [...state.context.oldResults, ...state.context.currentResults],
     start: () => {
       send({ type: "START" });
     },

--- a/src/use-transcription.ts
+++ b/src/use-transcription.ts
@@ -32,7 +32,7 @@ const transcriptionMachine = setup({
       | { type: "RESULTS"; results: TranscriptionResult[] },
   },
   actions: {
-    // TODO: find a way to force the caller to provide these actions
+    // TODO: find a way to force the caller to provide these actions, i.e. raise an error when one is missing
     startTranscription: () => {},
     stopTranscription: () => {},
   },


### PR DESCRIPTION
Closes to #2

Refactor transcription hooks to use a state machine with Idle and Transcribing states and start and stop transitions.

* **`src/use-web-speech-recognition.ts`**
  - Remove the `enabled` prop and use `start` and `stop` functions.
  - Take an `onResult` prop instead of returning `results` from `useState`.
  - Use `useEffect` to add/remove the event listener to ensure it is always removed and the identity of the `handleResult` function does not change after a re-render.

* **`src/app.tsx`**
  - Update the `useTranscription` hook to use `start` and `stop` functions instead of the `enabled` prop.
  - Call the `start` and `stop` functions when clicking the start/stop button.
  - Let `useTranscription` return the current state instead of managing an `isTranscribing` state.
  - Rename `state` to `transcriptionState`.

* **`package.json`**
  - Install `xstate` and `@xstate/react` packages.

* **`src/use-transcription.ts`**
  - Refactor to use a state machine with Idle and Transcribing states.
  - Implement start and stop transitions.
  - Remove the `enabled` prop and use `start` and `stop` functions.
  - Use `setup(...)` from XState v5 to define the types for the context and events.
  - Instead of `createMachine(...)`, use `setup(...).createMachine(...)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nimobeeren/talksnap/issues/2?shareId=e49d189d-1871-417b-b3f2-f095cb65d4f2).